### PR TITLE
Expand macros in version

### DIFF
--- a/bin/git-build-rpm
+++ b/bin/git-build-rpm
@@ -63,7 +63,7 @@ die "$spec_file does not exist; use --spec-file\n" unless -e $spec_file;
 # Extract the version from the spec file.
 my $version;
 eval {
-  $version = capturex( 'rpmspec', '-q', '--qf', '%{version}', $spec_file );
+  #$version = capturex( 'rpmspec', '-q', '--qf', '%{version}', $spec_file );
 };
 
 if( ! defined $version ) {
@@ -79,6 +79,10 @@ if( ! defined $version ) {
           }
       }
       $fh->close;
+      # try to expand macros
+      if( $v =~ /%/ ) {
+        $v = capturex( 'rpm', '-E', $v );
+      }
       $v;
   } or die "Cannot find version in $spec_file\n";
 }

--- a/bin/git-build-rpm
+++ b/bin/git-build-rpm
@@ -61,20 +61,31 @@ my $spec_file = file $opts{spec_file} || ('dist', "$name.spec");
 die "$spec_file does not exist; use --spec-file\n" unless -e $spec_file;
 
 # Extract the version from the spec file.
-my $version = do {
-    my $fh = $spec_file->open('<:encoding(UTF-8)')
-        or die "Cannot open $spec_file: $!\n";
-    my $v;
-    while (<$fh>) {
-        chomp;
-        if (/^version:\s*(\S+)/i) {
-            $v = $1;
-            last;
-        }
-    }
-    $fh->close;
-    $v;
-} or die "Cannot find version in $spec_file\n";
+my $version;
+eval {
+  $version = capturex( 'rpmspec', '-q', '--qf', '%{version}', $spec_file );
+};
+
+if( ! defined $version ) {
+  $version = do {
+      my $fh = $spec_file->open('<:encoding(UTF-8)')
+          or die "Cannot open $spec_file: $!\n";
+      my $v;
+      while (<$fh>) {
+          chomp;
+          if (/^version:\s*(.*)\s*$/i) {
+              $v = $1;
+              last;
+          }
+      }
+      $fh->close;
+      $v;
+  } or die "Cannot find version in $spec_file\n";
+}
+
+if( $version =~ /(%[{\(][^\)}]*[\)}])/ ) {
+  die("Unexpanded macro in $spec_file version: $1");
+}
 
 # Create the SPECS directory and copy the spec file to it.
 my $spec_dir = $dir->subdir('SPECS');


### PR DESCRIPTION
The version for the rpm is extracted from the spec file, but it
may contain macros which are not expanded by git-build-rpm.

This commit tries to get version from the rpmspec command which is
available in newer RPM versions:

  rpmspec -q --qf '%{version}' <specfile>

It will fall back to the old behaviour in case it fails, because
rpmspec is only shipped with rpm >= 4.9.

Additional it checks for unexpanded macros in the version string and
aborts build if macros are found.
